### PR TITLE
feat(dash): 新增 GPT 授权码管理页面及导航入口

### DIFF
--- a/src/app/dash/settings/gpt/page.tsx
+++ b/src/app/dash/settings/gpt/page.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { authFetch } from '@/lib/api';
+import { IconRefresh, IconCopy, IconCheck } from '@tabler/icons-react';
+
+interface OauthCodeResponse {
+  code: string;
+  expires_at: string;
+  expires_in: number;
+}
+
+export default function GptCodePage() {
+  const t = useTranslations("GptCodePage");
+  const [code, setCode] = useState<string>('');
+  const [expiresAt, setExpiresAt] = useState<number>(0);
+  const [remaining, setRemaining] = useState<number>(0);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const loadCode = useCallback(async (force: boolean) => {
+    try {
+      const url = force ? '/api/v1/user/oauth-code' : '/api/v1/user/oauth-code';
+      const res = await authFetch(url, { method: force ? 'POST' : 'GET' });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        toast.error(data.detail || t("loadError"));
+        return;
+      }
+      const data: OauthCodeResponse = await res.json();
+      setCode(data.code);
+      setExpiresAt(new Date(data.expires_at).getTime());
+      setRemaining(Math.max(0, data.expires_in));
+    } catch {
+      toast.error(t("loadError"));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    loadCode(false);
+  }, [loadCode]);
+
+  // 倒计时：每秒更新，过期后自动重新获取
+  useEffect(() => {
+    if (!expiresAt) return;
+    const timer = setInterval(() => {
+      const secs = Math.max(0, Math.floor((expiresAt - Date.now()) / 1000));
+      setRemaining(secs);
+      if (secs <= 0) {
+        setCode('');
+        loadCode(false);
+      }
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [expiresAt, loadCode]);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await loadCode(true);
+      toast.success(t("refreshed"));
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!code) return;
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      toast.success(t("copied"));
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error(t("copyFailed"));
+    }
+  };
+
+  return (
+    <div className="w-full max-w-2xl flex flex-col gap-4 py-4 md:gap-6 md:py-6">
+      <div className="space-y-1">
+        <h1 className="text-xl font-semibold">{t("title")}</h1>
+        <p className="text-sm text-muted-foreground">{t("desc")}</p>
+      </div>
+
+      {/* 授权码展示卡片 */}
+      <div className="rounded-xl bg-background p-6">
+        <div className="flex items-center justify-between mb-4">
+          <span className="text-sm text-muted-foreground">{t("codeLabel")}</span>
+          {code && (
+            <span className="text-xs text-muted-foreground">
+              {remaining > 0
+                ? t("expireIn", { s: remaining })
+                : t("expired")}
+            </span>
+          )}
+        </div>
+
+        {loading ? (
+          <div className="h-16 flex items-center justify-center text-sm text-muted-foreground">
+            {t("loading")}
+          </div>
+        ) : (
+          <div className="flex items-center gap-3">
+            <div className="flex-1 rounded-lg bg-muted px-4 py-4 text-center font-mono text-3xl font-semibold tracking-[0.4em]">
+              {code || '······'}
+            </div>
+            <Button variant="outline" size="icon" className="h-12 w-12 shrink-0" onClick={handleCopy} disabled={!code}>
+              {copied ? <IconCheck className="h-5 w-5 text-green-500" /> : <IconCopy className="h-5 w-5" />}
+            </Button>
+          </div>
+        )}
+
+        {/* 过期进度条 */}
+        {code && (
+          <div className="mt-4 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full rounded-full bg-primary transition-all duration-1000"
+              style={{ width: `${(remaining / 300) * 100}%` }}
+            />
+          </div>
+        )}
+
+        <div className="mt-5 flex items-center justify-between">
+          <p className="text-xs text-muted-foreground">{t("tips")}</p>
+          <Button variant="outline" size="sm" onClick={handleRefresh} disabled={refreshing || loading}>
+            <IconRefresh className={`mr-2 h-4 w-4 ${refreshing ? "animate-spin" : ""}`} />
+            {t("refresh")}
+          </Button>
+        </div>
+      </div>
+
+      {/* 使用说明 */}
+      <div className="rounded-xl bg-background p-6">
+        <h2 className="mb-4 text-sm font-semibold">{t("howToTitle")}</h2>
+        <ol className="space-y-3 text-sm text-foreground">
+          <li className="flex gap-3">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">1</span>
+            <span>{t("step1")}</span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">2</span>
+            <span>{t("step2")}</span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">3</span>
+            <span>{t("step3")}</span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dash/site-header.tsx
+++ b/src/components/dash/site-header.tsx
@@ -156,6 +156,9 @@ export function SiteHeader() {
                 <DropdownMenuItem onClick={() => router.push('/dash/accounts')} className="focus:bg-primary/50">
                   <span>{t("accounts")}</span>
                 </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => router.push('/dash/settings/gpt')} className="focus:bg-primary/50">
+                  <span>{t("gptCode")}</span>
+                </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => router.push('/dash/task')} className="focus:bg-primary/50">
                   <span>{t("task")}</span>
                 </DropdownMenuItem>

--- a/src/components/dash/user-sidebar.tsx
+++ b/src/components/dash/user-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { IconUser } from "@tabler/icons-react"
+import { IconUser, IconKey } from "@tabler/icons-react"
 
 import {
   Sidebar,
@@ -17,7 +17,8 @@ import {
 
 const USER_MENU_ITEMS = [
   { name: "Profile", href: "/dash/profile", icon: IconUser },
-  { name: "Apps", href: "/dash/accounts", icon: IconUser }
+  { name: "Apps", href: "/dash/accounts", icon: IconUser },
+  { name: "GPT Code", href: "/dash/settings/gpt", icon: IconKey }
 ]
 
 export function UserSidebar({

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -21,6 +21,7 @@
     "logout": "Logout",
     "dash": "Dashboard",
     "accounts": "Accounts",
+    "gptCode": "GPT Auth Code",
     "logs": "Logs"
   },
   "LoginPage": {
@@ -163,5 +164,24 @@
   },
   "SettingPage": {
     "myAccount": "My Account"
+  },
+  "GptCodePage": {
+    "title": "GPT Auth Code",
+    "desc": "Used to authorize OpenAI / ChatGPT connections to incremental.icu.",
+    "codeLabel": "Current Code",
+    "expireIn": "Expires in {s}s",
+    "expired": "Code expired, refreshing...",
+    "refresh": "Generate New Code",
+    "refreshed": "New code generated",
+    "copy": "Copy",
+    "copied": "Copied",
+    "copyFailed": "Copy failed",
+    "loading": "Loading...",
+    "loadError": "Failed to fetch code, please try again",
+    "howToTitle": "How to use",
+    "step1": "Connect incremental.icu in OpenAI / ChatGPT, your browser will be redirected to the authorization page.",
+    "step2": "Open this page and copy the 6-digit code above.",
+    "step3": "Enter the code on the authorization page and click \"Log in and authorize\" to complete the connection.",
+    "tips": "The code is valid for 5 minutes and can only be used once. Do not share it with anyone."
   }
 }

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -17,6 +17,7 @@
     "garminCn": "佳明中国版",
     "coros": "高驰",
     "accounts": "账号管理",
+    "gptCode": "GPT 授权码",
     "logs": "操作日志",
     "dash": "一键同步",
     "userSettings": "用户设置",
@@ -166,5 +167,24 @@
   },
   "SettingPage": {
     "myAccount": "我的账号"
+  },
+  "GptCodePage": {
+    "title": "GPT 授权码",
+    "desc": "用于 OpenAI / ChatGPT 连接 incremental.icu 时的登录授权。",
+    "codeLabel": "当前授权码",
+    "expireIn": "剩余 {s} 秒后过期",
+    "expired": "验证码已过期，正在刷新…",
+    "refresh": "生成新验证码",
+    "refreshed": "已生成新验证码",
+    "copy": "复制",
+    "copied": "已复制",
+    "copyFailed": "复制失败",
+    "loading": "加载中…",
+    "loadError": "获取验证码失败，请稍后重试",
+    "howToTitle": "如何使用",
+    "step1": "在 OpenAI / ChatGPT 中连接 incremental.icu，浏览器会跳转到授权页面。",
+    "step2": "打开本页面，复制上面的 6 位授权码。",
+    "step3": "在授权页面输入该验证码，点击「登录并授权」即可完成连接。",
+    "tips": "验证码 5 分钟内有效且只能使用一次，请勿泄露给他人。"
   }
 }


### PR DESCRIPTION
新增 `/dash/settings/gpt` 路径的授权码管理页面，支持授权码展示、复制、刷新及过期倒计时功能；在用户侧边栏和顶部导航下拉菜单中添加对应访问入口；补充简体中文和英文的国际化翻译文案。