### PR TITLE
refactor: 调整GPT代码页面的路由与菜单链接

### DIFF
--- a/src/app/dash/gpt/page.tsx
+++ b/src/app/dash/gpt/page.tsx
@@ -83,7 +83,7 @@ export default function GptCodePage() {
   };
 
   return (
-    <div className="w-full max-w-2xl flex flex-col gap-4 py-4 md:gap-6 md:py-6">
+    <div className="w-full max-w-2xl flex flex-col gap-4 py-4 mx-auto md:gap-6 md:py-6">
       <div className="space-y-1">
         <h1 className="text-xl font-semibold">{t("title")}</h1>
         <p className="text-sm text-muted-foreground">{t("desc")}</p>

--- a/src/components/dash/site-header.tsx
+++ b/src/components/dash/site-header.tsx
@@ -156,7 +156,7 @@ export function SiteHeader() {
                 <DropdownMenuItem onClick={() => router.push('/dash/accounts')} className="focus:bg-primary/50">
                   <span>{t("accounts")}</span>
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => router.push('/dash/settings/gpt')} className="focus:bg-primary/50">
+                <DropdownMenuItem onClick={() => router.push('/dash/gpt')} className="focus:bg-primary/50">
                   <span>{t("gptCode")}</span>
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => router.push('/dash/task')} className="focus:bg-primary/50">

--- a/src/components/dash/user-sidebar.tsx
+++ b/src/components/dash/user-sidebar.tsx
@@ -18,7 +18,7 @@ import {
 const USER_MENU_ITEMS = [
   { name: "Profile", href: "/dash/profile", icon: IconUser },
   { name: "Apps", href: "/dash/accounts", icon: IconUser },
-  { name: "GPT Code", href: "/dash/settings/gpt", icon: IconKey }
+  { name: "GPT Code", href: "/dash/gpt", icon: IconKey }
 ]
 
 export function UserSidebar({


### PR DESCRIPTION
将GPT代码页面从 `/dash/settings/gpt` 迁移至 `/dash/gpt`，更新侧边栏与顶部导航的跳转链接，并删除旧的页面文件。