### PR TITLE
修复(心脏SVG接口): 硬编码baseUrl为incremental.icu

### DIFF
--- a/src/app/heart/svg/route.tsx
+++ b/src/app/heart/svg/route.tsx
@@ -143,7 +143,9 @@ export async function GET(request: NextRequest) {
   const token = request.nextUrl.searchParams.get('token');
   const headers: Record<string, string> = {};
   if (token) headers['Authorization'] = `Bearer ${token}`;
-  const baseUrl = request.nextUrl.origin;
+  // Backend `/api/v1` is only proxied on incremental.icu; the Next.js app
+  // (i.incremental.icu) does not proxy it and Clerk blocks unauthenticated calls.
+  const baseUrl = 'https://incremental.icu';
 
   try {
     const [mainRes, yestRes] = await Promise.all([


### PR DESCRIPTION
由于仅incremental.icu域名会代理后端/api/v1接口，而当前Next.js应用所在的i.incremental.icu域名不支持该代理，且Clerk会拦截未认证的请求，以此保证接口调用正常。