### PR TITLE
chore(middleware): 更新公开路由匹配规则

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,7 +5,9 @@ const isPublicRoute = createRouteMatcher([
   "/sign-up(.*)",
   "/api/auth(.*)",
   "/api/v1(.*)",
-  "/heart/svg(.*)",
+  "/heart(.*)",
+  "/doc(.*)",
+  "/",
 ]);
 
 export default clerkMiddleware(async (auth, request) => {


### PR DESCRIPTION
将原有的仅/heart/svg子路径公开的规则扩展为匹配所有/heart开头的路径，新增根路径/和/doc路径作为无需认证的公开路由